### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a MCP server that defines tools for interacting with Linear via an MCP client.
 
+<a href="https://glama.ai/mcp/servers/stodrxddet">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/stodrxddet/badge" alt="Server Linear MCP server" />
+</a>
+
 ## Current Tools
 
 - `linear-search-issues`: Search for issues in Linear
@@ -100,4 +104,3 @@ This project was inspired by [jerhadf/linear-mcp-server](https://github.com/jerh
 ## License
 
 MIT
-


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Linear](https://glama.ai/mcp/servers/stodrxddet) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/stodrxddet">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/stodrxddet/badge" alt="Server Linear MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.